### PR TITLE
Database prefix and jquery fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Display Name - A [Nova](https://anodyne-productions.com/nova) Extension
 
 <p align="center">
-  <a href="https://github.com/reecesavage/nova-ext-display-name/releases/tag/v1.1.0"><img src="https://img.shields.io/badge/Version-v1.1.0-brightgreen.svg"></a>
+  <a href="https://github.com/reecesavage/nova-ext-display-name/releases/tag/v1.1.1"><img src="https://img.shields.io/badge/Version-v1.1.0-brightgreen.svg"></a>
   <a href="http://www.anodyne-productions.com/nova"><img src="https://img.shields.io/badge/Nova-v2.7.5+-orange.svg"></a>
   <a href="https://www.php.net"><img src="https://img.shields.io/badge/PHP-v8.x-blue.svg"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-red.svg"></a>
@@ -12,6 +12,7 @@ This extension allows characters to use a Display Name as an alternative to the 
 This extension requires:
 
 - Nova 2.7.5+
+- Nova Extension [`jquery`](https://github.com/jonmatterson/nova-ext-jquery)
 
 ## Upgrade Considerations
 - If upgrading Nova 2.6+ with this Nove Extension already deployed:

--- a/controllers/Manage.php
+++ b/controllers/Manage.php
@@ -80,7 +80,7 @@ class __extensions__nova_ext_display_name__Manage extends Nova_controller_admin
 
             if (in_array($attr, $requiredCharacterFields['char']) == true)
             {
-                $table = "nova_characters";
+                $table = "characters";
 
             }
             if (!empty($table))
@@ -221,7 +221,7 @@ class __extensions__nova_ext_display_name__Manage extends Nova_controller_admin
 
         $charFields = $this
             ->db
-            ->list_fields('nova_characters');
+            ->list_fields('characters');
        
 
         $leftFields = [];


### PR DESCRIPTION
- Fixed a bug that caused the site to crash, if the database prefix was not the default.
- Included the requirement for the jquery Nova Extension into the readme.md file.
- Updated the version number to v1.1.1 in the readme file.